### PR TITLE
Use system variable if set, otherwise default

### DIFF
--- a/jot.sh
+++ b/jot.sh
@@ -2,7 +2,7 @@
 
 INPUT="$*"
 
-JOT_ROUTE="/Users/"$USER"/Dropbox/notes/"
+JOT_ROUTE=${JOT_ROUTE:="/Users/"$USER"/Dropbox/notes/"}
 cd $JOT_ROUTE
 
 


### PR DESCRIPTION
This change will allow the script to attempt to read a system variable
of the name JOT_ROUTE, the same name as the local variable in the
script. If it is set, then the value of the variable is used and if it
is not set, then the current default is used. The last part ensures
backwards compatibility for existing users. There are several advantages
to this approach:

The currently recommended way to install jot is to clone the repository.
If a user does not want to use the default location, then they manually
have to edit the shell script and change the location. With this change
they can simply set the system variable to another location and it will
work without having to modify the script.

Some people also use multiple computers, and often these people
synchronize their dotfiles between the machines. This allows this group
of users to simply export the system variable in their bashrc file and
jot will automatically work across multiple systems.